### PR TITLE
Enable MockGenerator 

### DIFF
--- a/src/main/java/com/github/jmetzz/mock/MockGenerator.java
+++ b/src/main/java/com/github/jmetzz/mock/MockGenerator.java
@@ -1,6 +1,7 @@
-package com.github.jmetzz.service;
+package com.github.jmetzz.mock;
 
 
+import com.github.jmetzz.service.NumberGenerator;
 import com.github.jmetzz.service.annotations.Loggable;
 import com.github.jmetzz.service.annotations.ThirteenDigits;
 

--- a/src/main/resources/META-INF/beans.xml
+++ b/src/main/resources/META-INF/beans.xml
@@ -3,5 +3,11 @@
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
        http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
        version="1.1" bean-discovery-mode="all">
+    
+    <alternatives>
+        <class>
+            com.github.jmetzz.mock.MockGenerator
+        </class>
+    </alternatives>
 
 </beans>

--- a/src/test/java/com/github/jmetzz/service/BookServiceTest.java
+++ b/src/test/java/com/github/jmetzz/service/BookServiceTest.java
@@ -1,5 +1,6 @@
 package com.github.jmetzz.service;
 
+import com.github.jmetzz.mock.MockGenerator;
 import com.github.jmetzz.pojo.Book;
 import com.github.jmetzz.service.interceptors.LoggingInterceptor;
 import org.jboss.weld.environment.se.Weld;


### PR DESCRIPTION
Following changes...

1. Move the MockGenerator class to package com.github.jmetzz.mock, out of the test packages.
2. Enable MockGenerator in beans.xml (This is mandatory with @Alternatives in JSR-299 Specification).
